### PR TITLE
chore(deps): properly split dependencies from development

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   },
   "dependencies": {
     "@graphile/postgis": "file:graphile-postgis-v0.2.0.tgz",
+    "grafserv": "1.0.0",
+    "graphile": "5.0.0",
     "jose": "6.2.2",
     "postgraphile": "5.0.0"
   },
@@ -15,9 +17,6 @@
     "eslint": "10.2.0",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-prettier": "5.5.5",
-    "grafserv": "1.0.0",
-    "graphile": "5.0.0",
-    "jiti": "2.6.1",
     "prettier": "3.8.1",
     "typescript": "6.0.2",
     "typescript-eslint": "8.58.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@graphile/postgis':
         specifier: file:graphile-postgis-v0.2.0.tgz
         version: file:graphile-postgis-v0.2.0.tgz(@dataplan/pg@1.0.0(@dataplan/json@1.0.0(grafast@1.0.0(graphql@16.13.2)))(grafast@1.0.0(graphql@16.13.2))(graphile-config@1.0.0)(graphql@16.13.2)(pg-sql2@5.0.0)(pg@8.20.0))(postgraphile@5.0.0(8584502c90cf6ac14deed7b7712e56be))
+      grafserv:
+        specifier: 1.0.0
+        version: 1.0.0(@types/node@22.19.17)(grafast@1.0.0(graphql@16.13.2))(graphile-config@1.0.0)(graphql@16.13.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(ws@8.20.0)
+      graphile:
+        specifier: 5.0.0
+        version: 5.0.0(graphile-build@5.0.0(grafast@1.0.0(graphql@16.13.2))(graphile-config@1.0.0)(graphql@16.13.2))(graphile-config@1.0.0)(postgraphile@5.0.0(8584502c90cf6ac14deed7b7712e56be))
       jose:
         specifier: 6.2.2
         version: 6.2.2
@@ -33,15 +39,6 @@ importers:
       eslint-plugin-prettier:
         specifier: 5.5.5
         version: 5.5.5(eslint-config-prettier@10.1.8(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))(prettier@3.8.1)
-      grafserv:
-        specifier: 1.0.0
-        version: 1.0.0(@types/node@22.19.17)(grafast@1.0.0(graphql@16.13.2))(graphile-config@1.0.0)(graphql@16.13.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(ws@8.20.0)
-      graphile:
-        specifier: 5.0.0
-        version: 5.0.0(graphile-build@5.0.0(grafast@1.0.0(graphql@16.13.2))(graphile-config@1.0.0)(graphql@16.13.2))(graphile-config@1.0.0)(postgraphile@5.0.0(8584502c90cf6ac14deed7b7712e56be))
-      jiti:
-        specifier: 2.6.1
-        version: 2.6.1
       prettier:
         specifier: 3.8.1
         version: 3.8.1
@@ -2705,7 +2702,8 @@ snapshots:
 
   iterall@1.3.0: {}
 
-  jiti@2.6.1: {}
+  jiti@2.6.1:
+    optional: true
 
   jose@6.2.2: {}
 


### PR DESCRIPTION
This pull request updates the `package.json` dependencies by moving several packages from `devDependencies` to `dependencies` and removing some unused development dependencies. The main focus is to ensure that runtime dependencies are correctly categorized for production use.