### PR TITLE
ci(docker): migrate to smoke test script

### DIFF
--- a/.github/smoke-test.sh
+++ b/.github/smoke-test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="${SMOKE_TEST_IMAGE:?SMOKE_TEST_IMAGE not set}"
+
+echo "::group::Environment"
+echo "Image: $IMAGE"
+echo "Platform: $(uname -m)"
+echo "Docker: $(docker --version 2>/dev/null || echo 'not found')"
+echo "::endgroup::"
+
+cleanup() {
+  echo "::group::Cleanup"
+  echo "Removing containers and network..."
+  docker rm --force postgraphile-smoke postgraphile-smoke-db >/dev/null 2>&1 || true
+  docker network rm postgraphile-smoke >/dev/null 2>&1 || true
+  rm -f private.pem public.pem || true
+  rm -rf env-vars || true
+  echo "Cleanup complete."
+  echo "::endgroup::"
+}
+trap cleanup EXIT
+
+echo "::group::Generate ES256 key pair"
+openssl ecparam -genkey -name prime256v1 | \
+  openssl pkcs8 -topk8 -nocrypt -outform PEM > private.pem
+openssl ec -in private.pem -pubout -outform PEM > public.pem
+echo "Key pair generated."
+echo "::endgroup::"
+
+echo "::group::Create test network"
+docker network create postgraphile-smoke || true
+echo "Network ready."
+echo "::endgroup::"
+
+echo "::group::Start PostgreSQL"
+docker run --detach --name postgraphile-smoke-db \
+  --network postgraphile-smoke \
+  -e POSTGRES_DB=postgraphile \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  postgres:18-alpine
+
+echo "Waiting for PostgreSQL to be ready..."
+until docker exec postgraphile-smoke-db psql -U postgres -d postgraphile \
+  -c 'CREATE SCHEMA IF NOT EXISTS postgraphile'; do
+  sleep 1
+done
+echo "PostgreSQL is ready."
+echo "::endgroup::"
+
+echo "::group::Start PostGraphile"
+mkdir -p env-vars
+echo "postgresql://postgres:postgres@postgraphile-smoke-db:5432/postgraphile" > env-vars/POSTGRAPHILE_CONNECTION
+echo "postgresql://postgres:postgres@postgraphile-smoke-db:5432/postgraphile" > env-vars/POSTGRAPHILE_OWNER_CONNECTION
+echo "true" > env-vars/TURNSTILE_BYPASS
+cp private.pem env-vars/POSTGRAPHILE_JWT_SECRET_KEY
+cp public.pem env-vars/POSTGRAPHILE_JWT_PUBLIC_KEY
+
+docker run --detach --name postgraphile-smoke \
+  --network postgraphile-smoke \
+  --volume "$(pwd)/env-vars:/run/environment-variables:ro" \
+  -p 5678:5678 \
+  "$IMAGE"
+echo "PostGraphile container started."
+echo "::endgroup::"
+
+echo "::group::Wait for healthy"
+for i in $(seq 1 60); do
+  STATUS=$(docker inspect --format='{{.State.Health.Status}}' postgraphile-smoke)
+  if [ "$STATUS" = "healthy" ]; then
+    echo "Container is healthy after ${i}s"
+    break
+  fi
+  if [ "$STATUS" = "unhealthy" ]; then
+    echo "Container became unhealthy"
+    docker logs postgraphile-smoke
+    exit 1
+  fi
+  if [ "$((i % 10))" -eq 0 ]; then
+    echo "Still waiting... (${i}s)"
+  fi
+  sleep 1
+done
+if [ "$STATUS" != "healthy" ]; then
+  echo "Timeout waiting for healthy status"
+  docker logs postgraphile-smoke
+  exit 1
+fi
+echo "::endgroup::"
+
+echo "::group::Smoke test GraphQL endpoint"
+RESPONSE=$(curl -fsS -X POST http://localhost:5678/graphql \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"{ __typename }"}') || {
+  echo "Request failed, container logs:"
+  docker logs postgraphile-smoke
+  exit 1
+}
+echo "Response: $RESPONSE"
+echo "$RESPONSE" | jq -e '(.data.__typename // "") != "" and (.errors | not)'
+echo "GraphQL endpoint OK."
+echo "::endgroup::"
+
+echo "Smoke test passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,105 +29,15 @@ jobs:
       PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
     with:
       DRY_RUN: true
-  smoke-test:
-    name: Docker smoke test
-    needs: release_semantic_dry
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
-      - name: Build production image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: .
-          target: production
-          tags: postgraphile:test
-          load: true
-
-      - name: Generate ES256 key pair
-        run: |
-          openssl ecparam -genkey -name prime256v1 | \
-            openssl pkcs8 -topk8 -nocrypt -outform PEM > private.pem
-          openssl ec -in private.pem -pubout -outform PEM > public.pem
-
-      - name: Create test network
-        run: docker network create postgraphile-test || true
-
-      - name: Start PostgreSQL
-        run: |
-          docker run --detach --name postgraphile-db \
-            --network postgraphile-test \
-            -e POSTGRES_DB=postgraphile \
-            -e POSTGRES_USER=postgres \
-            -e POSTGRES_PASSWORD=postgres \
-            postgres:18-alpine
-          until docker exec postgraphile-db psql -U postgres -d postgraphile \
-            -c 'CREATE SCHEMA IF NOT EXISTS postgraphile'; do
-            sleep 1
-          done
-
-      - name: Start PostGraphile
-        run: |
-          mkdir -p env-vars
-          echo "postgresql://postgres:postgres@postgraphile-db:5432/postgraphile" > env-vars/POSTGRAPHILE_CONNECTION
-          echo "postgresql://postgres:postgres@postgraphile-db:5432/postgraphile" > env-vars/POSTGRAPHILE_OWNER_CONNECTION
-          echo "true" > env-vars/TURNSTILE_BYPASS
-          cp private.pem env-vars/POSTGRAPHILE_JWT_SECRET_KEY
-          cp public.pem env-vars/POSTGRAPHILE_JWT_PUBLIC_KEY
-          docker run --detach --name postgraphile \
-            --network postgraphile-test \
-            --volume "$(pwd)/env-vars:/run/environment-variables:ro" \
-            -p 5678:5678 \
-            postgraphile:test
-
-      - name: Wait for healthy
-        run: |
-          for i in $(seq 1 60); do
-            STATUS=$(docker inspect --format='{{.State.Health.Status}}' postgraphile)
-            if [ "$STATUS" = "healthy" ]; then
-              echo "Container is healthy after ${i}s"
-              exit 0
-            fi
-            if [ "$STATUS" = "unhealthy" ]; then
-              echo "Container became unhealthy"
-              docker logs postgraphile
-              exit 1
-            fi
-            sleep 1
-          done
-          echo "Timeout waiting for healthy status"
-          docker logs postgraphile
-          exit 1
-
-      - name: Smoke test GraphQL endpoint
-        run: |
-          RESPONSE=$(curl -fsS -X POST http://localhost:5678/graphql \
-            -H 'Content-Type: application/json' \
-            -d '{"query":"{ __typename }"}') || {
-            echo "Request failed, container logs:"
-            docker logs postgraphile
-            exit 1
-          }
-          echo "Response: $RESPONSE"
-          echo "$RESPONSE" | jq -e '(.data.__typename // "") != "" and (.errors | not)'
-
-      - name: Cleanup
-        if: always()
-        run: |
-          docker rm --force postgraphile postgraphile-db || true
-          docker network rm postgraphile-test || true
   build:
-    needs: smoke-test
+    needs: release_semantic_dry
     name: Build
     uses: dargmuesli/github-actions/.github/workflows/docker.yml@6ea5949acc790897796b3c8ab130128ad64f8b17 # 5.6.0
     permissions:
       packages: write
     with:
       PLATFORMS: linux/amd64,linux/arm64
+      SMOKE_TEST_SCRIPT: .github/smoke-test.sh
       TAG: ${{ needs.release_semantic_dry.outputs.new_release_version }}
   release_semantic:
     needs: build


### PR DESCRIPTION
This pull request refactors how Docker smoke tests are executed in CI and updates workflow dependencies to a newer version. The smoke test logic is now moved into a dedicated script and integrated into the main build job, simplifying the workflow and improving maintainability.

**CI workflow improvements:**

* The standalone `smoke-test` job is removed from `.github/workflows/ci.yml`, and smoke testing is now handled via a new `SMOKE_TEST_SCRIPT` argument in the `build` job, which references the new `.github/smoke-test.sh` script. This centralizes and streamlines the smoke test process.
* The smoke test logic (building the image, setting up the test database, running health checks, and GraphQL endpoint verification) is extracted into `.github/smoke-test.sh` for easier reuse and maintenance.

**Dependency updates:**

* All references to the shared workflow actions from `dargmuesli/github-actions` are updated from version `5.5.3` to `5.6.0` in `.github/workflows/ci.yml` and `.github/workflows/release-schedule.yml`, ensuring the latest improvements and fixes are used.