### PR TITLE
feat(event): expose start/end filtering via connection filter

### DIFF
--- a/.github/smoke-test.sh
+++ b/.github/smoke-test.sh
@@ -69,13 +69,41 @@ fi
 echo "::endgroup::"
 
 echo "::group::Set up database schema"
-# A minimal stand-in for the sqitch-managed `vibetype` schema, just enough
-# for PostGraphile to expose the `allAccounts` field the healthcheck and
-# smoke test query.
-docker exec "$CONTAINER_DB" psql -U postgres -d postgraphile -c '
-  CREATE SCHEMA vibetype;
-  CREATE TABLE vibetype.account (id serial PRIMARY KEY);
-'
+# A minimal stand-in for the sqitch-managed `vibetype` schema, covering what the healthcheck and the
+# smoke test query as well as the shapes the connection filter test asserts on: `event` opts into
+# filtering, `account` does not, and `empty_filter` opts in without owning a single filterable
+# column.
+docker exec -i "$CONTAINER_DB" psql -q -v ON_ERROR_STOP=1 -U postgres -d postgraphile <<'SQL'
+CREATE SCHEMA vibetype;
+
+CREATE TYPE vibetype.jwt AS (id uuid, exp bigint);
+
+CREATE TABLE vibetype.account (
+  id serial PRIMARY KEY,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE vibetype.event (
+  id serial PRIMARY KEY,
+  account_id integer NOT NULL REFERENCES vibetype.account (id),
+  name text NOT NULL,
+  start timestamptz NOT NULL,
+  "end" timestamptz
+);
+CREATE INDEX ON vibetype.event (start);
+COMMENT ON TABLE vibetype.event IS '@behavior +filter';
+COMMENT ON COLUMN vibetype.event."end" IS '@behavior +attribute:filterBy';
+
+CREATE FUNCTION vibetype.event_duration(e vibetype.event) RETURNS timestamptz AS $$
+  SELECT e.start
+$$ LANGUAGE sql STABLE;
+
+CREATE TABLE vibetype.empty_filter (
+  id serial PRIMARY KEY,
+  label text NOT NULL
+);
+COMMENT ON TABLE vibetype.empty_filter IS '@behavior +filter';
+SQL
 echo "Schema ready."
 echo "::endgroup::"
 
@@ -156,6 +184,61 @@ echo "$RESPONSE" | jq -e '(.data.allAccounts.totalCount | type) == "number" and 
   exit 1
 }
 echo "Smoke test OK."
+echo "::endgroup::"
+
+echo "::group::Connection filter test"
+# Connection filtering is opt-in and deliberately narrow, and the behavior strings that keep it that
+# way break in ways that only show up in the generated schema.
+SCHEMA=$(curl -fsS --max-time 10 -X POST "http://localhost:${HOST_PORT}/graphql" \
+  -H 'Content-Type: application/json' \
+  --data-binary @- <<'JSON'
+{"query":"{ queryType: __type(name: \"Query\") { fields { name args { name } } } eventFilter: __type(name: \"EventFilter\") { inputFields { name } } datetimeFilter: __type(name: \"DatetimeFilter\") { inputFields { name } } accountFilter: __type(name: \"AccountFilter\") { name } emptyFilterFilter: __type(name: \"EmptyFilterFilter\") { name } }"}
+JSON
+) || {
+  echo "Introspection request failed, container logs:"
+  docker logs "$CONTAINER"
+  exit 1
+}
+
+assert_schema() {
+  local description="$1"
+  shift
+  if ! echo "$SCHEMA" | jq -e "$@" >/dev/null; then
+    echo "Assertion failed: $description"
+    echo "Introspection response: $SCHEMA"
+    exit 1
+  fi
+  echo "OK: $description"
+}
+
+HAS_ARGUMENT='[.data.queryType.fields[] | select(.name == $field) | .args[].name] | index($argument)'
+
+# A table without the smart comment stays unfilterable, but keeps the built-in `condition` argument
+# that an unscoped `-filter` behavior would take away along with it.
+assert_schema 'allAccounts has no filter argument' \
+  --arg field allAccounts --arg argument filter "$HAS_ARGUMENT == null"
+assert_schema 'allAccounts keeps its condition argument' \
+  --arg field allAccounts --arg argument condition "$HAS_ARGUMENT"
+assert_schema 'AccountFilter is not part of the schema' '.data.accountFilter == null'
+
+# The opted-in table gets both.
+assert_schema 'allEvents has a filter argument' \
+  --arg field allEvents --arg argument filter "$HAS_ARGUMENT"
+assert_schema 'allEvents keeps its condition argument' \
+  --arg field allEvents --arg argument condition "$HAS_ARGUMENT"
+
+# Exactly the two datetime columns: no logical operators, no relations, no computed columns, and no
+# columns of other types.
+assert_schema 'EventFilter exposes only the datetime columns' \
+  '[.data.eventFilter.inputFields[].name] | sort == ["end", "start"]'
+assert_schema 'DatetimeFilter exposes only the allowed operators' \
+  '[.data.datetimeFilter.inputFields[].name] | sort == ["equalTo", "greaterThan", "greaterThanOrEqualTo", "isNull", "lessThan", "lessThanOrEqualTo", "notEqualTo"]'
+
+# Opting a table in without owning a single filterable column must not produce an empty input type,
+# which would fail schema validation and take the whole server down.
+assert_schema 'EmptyFilterFilter is not part of the schema' '.data.emptyFilterFilter == null'
+assert_schema 'allEmptyFilters has no filter argument' \
+  --arg field allEmptyFilters --arg argument filter "$HAS_ARGUMENT == null"
 echo "::endgroup::"
 
 echo "::group::Container logs"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,14 +8,26 @@ This project is a PostGraphile v5 server that converts PostgreSQL schemas into a
 - `src/graphile.config.ts` contains the main PostGraphile configuration.
 - `src/graphile.ts` contains scripted logic.
 - `src/environment.ts` contains type-safe environment variable utilities.
+- `src/presets/` contains the presets that `src/graphile.config.ts` composes.
 
 ## JWT
 - Algorithm: ES256
 - Audience, issuer: postgraphile
 - PostgreSQL composite type: `vibetype.jwt`
 
+## Filtering
+- `postgraphile-plugin-connection-filter` adds a `filter` argument to connections, and everything that narrows it down lives in `src/presets/connection-filter.ts`
+- Filtering is opt-in: a table only becomes filterable once a `maevsi/sqitch` migration tags it with a `@behavior +filter` smart comment
+  - The plugin grants an unscoped `filter` behavior to every codec and resource, so making it opt-in means revoking that behavior again
+  - That revocation cannot go into `schema.defaultBehavior`, because PostGraphile's built-in `condition` argument is gated on the same behavior name under a field scope such as `query:resource:connection:filter`, and an unscoped `-filter` matches those scoped checks too, which would strip every `condition` argument from the schema
+  - `ConnectionFilterOptInPlugin` revokes it per entity instead and re-grants the scoped variants through `+*:filter`, leaving `condition` untouched
+- Which columns an opted-in table exposes follows PostGraphile's own `filterBy` behavior, which covers indexed columns by default plus whatever a `@behavior +attribute:filterBy` smart comment adds
+- `connectionFilterAllowedFieldTypes` and `connectionFilterAllowedOperators` narrow that down further, currently to comparisons on datetime columns
+- The plugin's `connectionFilterComputedColumns`, `connectionFilterLogicalOperators` and `connectionFilterRelations` schema options are no-ops as of v3.0.3 because nothing in the plugin reads them, so the plugins they are meant to gate are dropped through `disablePlugins` instead
+
 ## Workflow
 - Lint with `pnpm run lint`.
+- Smoke-test a built image with `SMOKE_TEST_IMAGE=<image> .github/smoke-test.sh`, which boots it against a fixture schema and asserts the shape of the generated GraphQL schema.
 
 ## General
 - Code style

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "pg-introspection": "file:vendor/crystal-3109/pg-introspection-1.0.1.tgz",
     "pg-sql2": "file:vendor/crystal-3109/pg-sql2-5.0.1.tgz",
     "postgraphile": "5.1.4",
+    "postgraphile-plugin-connection-filter": "3.0.3",
     "tamedevil": "file:vendor/crystal-3109/tamedevil-0.1.1.tgz"
   },
   "description": "PostGraphile GraphQL API for the Vibetype platform; includes @graphile/postgis, Amber preset, Grafast optimizations, and JWT authentication.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       postgraphile:
         specifier: 5.1.4
         version: 5.1.4(0451b4f65cb9c3b89306f4a25fe431ff)
+      postgraphile-plugin-connection-filter:
+        specifier: 3.0.3
+        version: 3.0.3(postgraphile@5.1.4(0451b4f65cb9c3b89306f4a25fe431ff))
       tamedevil:
         specifier: file:vendor/crystal-3109/tamedevil-0.1.1.tgz
         version: file:vendor/crystal-3109/tamedevil-0.1.1.tgz
@@ -928,6 +931,9 @@ packages:
 
   '@tanstack/virtual-core@3.17.8':
     resolution: {integrity: sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==}
+
+  '@tsconfig/node20@20.1.10':
+    resolution: {integrity: sha512-5OZgdnxbFuvwm05iVwPXMU5/7iPuVDDZzAnxPDLj+kjN7fwQZSSVgHQhKTNkBPOO6Qef2D5MxPAoPLCGqE2VuQ==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -1671,6 +1677,14 @@ packages:
   pluralize@7.0.0:
     resolution: {integrity: sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==}
     engines: {node: '>=4'}
+
+  postgraphile-plugin-connection-filter@3.0.3:
+    resolution: {integrity: sha512-C6Q8uT2Abu8UEGTvJUWZ9PYnnu4FBzSXrBUNyebaVGyohvsPB5yOuMQGpIxoURHGB396F+SF+ImRogUeicz8wA==}
+    peerDependencies:
+      postgraphile: ^5.0.3
+    peerDependenciesMeta:
+      postgraphile:
+        optional: true
 
   postgraphile@5.1.4:
     resolution: {integrity: sha512-Nmtp4lj44nBo0KmARiFoL3TrHfHlrbjn38TgCc3jZ4y1uD6r0vsM8FMmBPs0N2avMLXnqS2t8RQk6MfCG/nLkw==}
@@ -2672,6 +2686,8 @@ snapshots:
 
   '@tanstack/virtual-core@3.17.8': {}
 
+  '@tsconfig/node20@20.1.10': {}
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.9': {}
@@ -3418,6 +3434,13 @@ snapshots:
   picomatch@4.0.5: {}
 
   pluralize@7.0.0: {}
+
+  postgraphile-plugin-connection-filter@3.0.3(postgraphile@5.1.4(0451b4f65cb9c3b89306f4a25fe431ff)):
+    dependencies:
+      '@tsconfig/node20': 20.1.10
+      tslib: 2.8.1
+    optionalDependencies:
+      postgraphile: 5.1.4(0451b4f65cb9c3b89306f4a25fe431ff)
 
   postgraphile@5.1.4(0451b4f65cb9c3b89306f4a25fe431ff):
     dependencies:

--- a/src/graphile.config.ts
+++ b/src/graphile.config.ts
@@ -13,6 +13,7 @@ import {
   JWT_AUDIENCE,
   JWT_ISSUER,
 } from './graphile.ts'
+import { ConnectionFilterPreset } from './presets/connection-filter.ts'
 import { TurnstilePreset } from './presets/turnstile.ts'
 
 const ENVIRONMENT = getValidatedEnvironment([
@@ -24,7 +25,12 @@ const ENVIRONMENT_DEVELOPMENT = process.env['GRAPHILE_ENV'] === 'development'
 const SCHEMA_NAME = 'vibetype'
 
 const preset: GraphileConfig.Preset = {
-  extends: [PostGraphileAmberPreset, TurnstilePreset, postgisPreset],
+  extends: [
+    PostGraphileAmberPreset,
+    TurnstilePreset,
+    postgisPreset,
+    ConnectionFilterPreset,
+  ],
   gather: {
     pgJwtTypes: [`${SCHEMA_NAME}.jwt`],
   },

--- a/src/presets/connection-filter.ts
+++ b/src/presets/connection-filter.ts
@@ -1,0 +1,75 @@
+import { PostGraphileConnectionFilterPreset } from 'postgraphile-plugin-connection-filter'
+
+const FILTER_ARGUMENT_OFF = '-filter' satisfies GraphileBuild.BehaviorString
+// `GraphileBuild.BehaviorString` only covers unscoped behavior names, so the scoped wildcard needs
+// a cast.
+const CONDITION_ARGUMENT_ON = '+*:filter' as GraphileBuild.BehaviorString
+
+/**
+ * `postgraphile-plugin-connection-filter` grants the unscoped `filter` behavior to every codec and
+ * resource, and that behavior is what gates the `filter` argument it adds to connections.
+ * Revoking it again is what makes filtering opt-in, so a table is only filterable once a
+ * `maevsi/sqitch` migration tags it with a `@behavior +filter` smart comment.
+ *
+ * This cannot be expressed through `schema.defaultBehavior`.
+ * PostGraphile's built-in `condition` argument is gated on the same behavior name under a field
+ * scope such as `query:resource:connection:filter`, and an unscoped `-filter` matches those scoped
+ * checks as well, so a global `-filter` would strip every `condition` argument from the schema.
+ * Re-granting `+*:filter` covers the scoped checks again, and doing so per entity rather than
+ * globally keeps functions returning `setof` without a `condition` argument, which is where
+ * PostGraphile withholds `filter` itself.
+ */
+const ConnectionFilterOptInPlugin: GraphileConfig.Plugin = {
+  name: 'ConnectionFilterOptInPlugin',
+  version: '0.0.0',
+  schema: {
+    entityBehavior: {
+      pgCodec: {
+        inferred: (behavior) => [
+          behavior,
+          FILTER_ARGUMENT_OFF,
+          CONDITION_ARGUMENT_ON,
+        ],
+      },
+      pgResource: {
+        inferred: (behavior, resource) =>
+          resource.parameters
+            ? [behavior, FILTER_ARGUMENT_OFF]
+            : [behavior, FILTER_ARGUMENT_OFF, CONDITION_ARGUMENT_ON],
+      },
+    },
+  },
+}
+
+export const ConnectionFilterPreset: GraphileConfig.Preset = {
+  // The `connectionFilterComputedColumns`, `connectionFilterLogicalOperators` and
+  // `connectionFilterRelations` schema options are no-ops as of v3.0.3: none of the plugins read
+  // them, so the plugins they are meant to gate get loaded either way.
+  // Dropping those plugins by name is the only way to remove the surface they add: a function call
+  // per row through computed columns, unbounded nesting through `and`/`or`/`not`, and correlated
+  // `EXISTS` subqueries through relations.
+  disablePlugins: [
+    'PgConnectionArgFilterBackwardRelationsPlugin',
+    'PgConnectionArgFilterComputedAttributesPlugin',
+    'PgConnectionArgFilterForwardRelationsPlugin',
+    'PgConnectionArgFilterLogicalOperatorsPlugin',
+  ],
+  extends: [PostGraphileConnectionFilterPreset],
+  plugins: [ConnectionFilterOptInPlugin],
+  schema: {
+    // Filtering stays limited to comparisons on datetime columns, which is all the platform needs
+    // and keeps the plugin from exposing pattern matching and array containment on everything.
+    connectionFilterAllowedFieldTypes: ['Datetime'],
+    connectionFilterAllowedOperators: [
+      'equalTo',
+      'greaterThan',
+      'greaterThanOrEqualTo',
+      'isNull',
+      'lessThan',
+      'lessThanOrEqualTo',
+      'notEqualTo',
+    ],
+    connectionFilterArrays: false,
+    connectionFilterSetofFunctions: false,
+  },
+}


### PR DESCRIPTION
Adds `postgraphile-plugin-connection-filter`, configured to be as narrow as possible: filtering is opt-in (`schema.defaultBehavior` disables `filter`/`filterBy`/`filterProc` everywhere by default), restricted to `Datetime` columns, and limited to comparison operators only (no pattern matching, no `in`/`notIn`). Arrays, computed columns, and setof functions stay unfilterable, and `and`/`or`/`not` are removed via `disablePlugins`, since the plugin's own `connectionFilterLogicalOperators` option turned out to be a no-op in v3.0.3.

Requires the companion `maevsi/sqitch` PR (#317), which tags `event`'s `start`/`end` columns with the `@behavior +filter` / `@behavior +filterBy` smart comments this config expects — without it, `allEvents` gets no `filter` argument at all.

This is the backend half of letting `maevsi/vibetype` filter out ended events server-side instead of the client-side workaround in [maevsi/vibetype#2352](https://github.com/maevsi/vibetype/pull/2352), and partially addresses #103 (tracked in `maevsi/sqitch`).