### PR TITLE
ci(test): smoke test graphql instead of ruru

### DIFF
--- a/.github/smoke-test.sh
+++ b/.github/smoke-test.sh
@@ -41,6 +41,9 @@ docker network inspect "$NETWORK" >/dev/null 2>&1 || docker network create "$NET
 echo "Network ready."
 echo "::endgroup::"
 
+ENV_DIR="$(mktemp -d -p "$(pwd)" smoke-env.XXXXXX)"
+chmod 755 "$ENV_DIR"
+
 echo "::group::Start PostgreSQL"
 docker run --detach --name "$CONTAINER_DB" \
   --network "$NETWORK" \
@@ -50,17 +53,27 @@ docker run --detach --name "$CONTAINER_DB" \
   postgres:18-alpine
 
 echo "Waiting for PostgreSQL to be ready..."
-until docker exec "$CONTAINER_DB" psql -U postgres -d postgraphile \
-  -c 'CREATE SCHEMA IF NOT EXISTS postgraphile'; do
+until docker exec "$CONTAINER_DB" pg_isready -U postgres -d postgraphile >/dev/null 2>&1; do
   sleep 1
 done
 echo "PostgreSQL is ready."
 echo "::endgroup::"
 
-echo "::group::Start"
-ENV_DIR="$(mktemp -d -p "$(pwd)" smoke-env.XXXXXX)"
-chmod 755 "$ENV_DIR"
+echo "::group::Deploy database migrations"
+# The `vibetype` schema (incl. the `account` table the healthcheck and smoke
+# test query) is owned by the sqitch repo; deploy it with the same image
+# version pinned in the Dockerfile's dependency stage.
+SQITCH_IMAGE="$(grep -m1 '^FROM .*/sqitch:' Dockerfile | awk '{print $2}')"
+echo "Sqitch image: $SQITCH_IMAGE"
+echo "db:pg://postgres:postgres@${CONTAINER_DB}:5432/postgraphile" > "$ENV_DIR/sqitch-target"
+docker run --rm \
+  --network "$NETWORK" \
+  --volume "$ENV_DIR/sqitch-target:/run/secrets/sqitch-target:ro" \
+  "$SQITCH_IMAGE"
+echo "Migrations deployed."
+echo "::endgroup::"
 
+echo "::group::Start"
 echo "postgresql://postgres:postgres@${CONTAINER_DB}:5432/postgraphile" > "$ENV_DIR/POSTGRAPHILE_CONNECTION"
 echo "postgresql://postgres:postgres@${CONTAINER_DB}:5432/postgraphile" > "$ENV_DIR/POSTGRAPHILE_OWNER_CONNECTION"
 echo "true" > "$ENV_DIR/TURNSTILE_BYPASS"
@@ -122,13 +135,13 @@ echo "::endgroup::"
 echo "::group::Smoke test"
 RESPONSE=$(curl -fsS --max-time 10 -X POST "http://localhost:${HOST_PORT}/graphql" \
   -H 'Content-Type: application/json' \
-  -d '{"query":"{ __typename }"}') || {
+  -d '{"query":"query health { allAccounts { totalCount } }"}') || {
   echo "Request failed, container logs:"
   docker logs "$CONTAINER"
   exit 1
 }
 echo "Response: $RESPONSE"
-echo "$RESPONSE" | jq -e '(.data.__typename // "") != "" and (.errors | not)' || {
+echo "$RESPONSE" | jq -e '(.data.allAccounts.totalCount | type) == "number" and (.errors | not)' || {
   echo "Response assertion failed, container logs:"
   docker logs "$CONTAINER"
   exit 1

--- a/.github/smoke-test.sh
+++ b/.github/smoke-test.sh
@@ -41,9 +41,6 @@ docker network inspect "$NETWORK" >/dev/null 2>&1 || docker network create "$NET
 echo "Network ready."
 echo "::endgroup::"
 
-ENV_DIR="$(mktemp -d -p "$(pwd)" smoke-env.XXXXXX)"
-chmod 755 "$ENV_DIR"
-
 echo "::group::Start PostgreSQL"
 docker run --detach --name "$CONTAINER_DB" \
   --network "$NETWORK" \
@@ -59,21 +56,21 @@ done
 echo "PostgreSQL is ready."
 echo "::endgroup::"
 
-echo "::group::Deploy database migrations"
-# The `vibetype` schema (incl. the `account` table the healthcheck and smoke
-# test query) is owned by the sqitch repo; deploy it with the same image
-# version pinned in the Dockerfile's dependency stage.
-SQITCH_IMAGE="$(grep -m1 '^FROM .*/sqitch:' Dockerfile | awk '{print $2}')"
-echo "Sqitch image: $SQITCH_IMAGE"
-echo "db:pg://postgres:postgres@${CONTAINER_DB}:5432/postgraphile" > "$ENV_DIR/sqitch-target"
-docker run --rm \
-  --network "$NETWORK" \
-  --volume "$ENV_DIR/sqitch-target:/run/secrets/sqitch-target:ro" \
-  "$SQITCH_IMAGE"
-echo "Migrations deployed."
+echo "::group::Set up database schema"
+# A minimal stand-in for the sqitch-managed `vibetype` schema, just enough
+# for PostGraphile to expose the `allAccounts` field the healthcheck and
+# smoke test query.
+docker exec "$CONTAINER_DB" psql -U postgres -d postgraphile -c '
+  CREATE SCHEMA vibetype;
+  CREATE TABLE vibetype.account (id serial PRIMARY KEY);
+'
+echo "Schema ready."
 echo "::endgroup::"
 
 echo "::group::Start"
+ENV_DIR="$(mktemp -d -p "$(pwd)" smoke-env.XXXXXX)"
+chmod 755 "$ENV_DIR"
+
 echo "postgresql://postgres:postgres@${CONTAINER_DB}:5432/postgraphile" > "$ENV_DIR/POSTGRAPHILE_CONNECTION"
 echo "postgresql://postgres:postgres@${CONTAINER_DB}:5432/postgraphile" > "$ENV_DIR/POSTGRAPHILE_OWNER_CONNECTION"
 echo "true" > "$ENV_DIR/TURNSTILE_BYPASS"


### PR DESCRIPTION
This pull request updates the smoke test script to ensure the test environment more closely matches production by creating the minimal required database schema and improving the health check. The main changes are grouped into database setup and smoke test improvements:

**Database setup:**
* The script now waits for PostgreSQL to be ready using `pg_isready` instead of attempting to create a schema in a loop, making the readiness check more robust.
* After confirming PostgreSQL is ready, the script explicitly creates the `vibetype` schema and a minimal `account` table, ensuring the necessary structure exists for the smoke test.

**Smoke test improvements:**
* The smoke test GraphQL query was updated to request `{ allAccounts { totalCount } }`, matching the expected production health check, instead of the previous `{ __typename }`.
* The response assertion now checks that `allAccounts.totalCount` is a number and that there are no errors, providing a more meaningful validation of the API.