### PR TITLE
perf(turnstile): forward mutations only

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "graphile-build": "file:vendor/crystal-3109/graphile-build-5.1.0.tgz",
     "graphile-build-pg": "file:vendor/crystal-3109/graphile-build-pg-5.1.0.tgz",
     "graphile-config": "file:vendor/crystal-3109/graphile-config-1.1.0.tgz",
+    "graphql": "16.14.2",
     "jose": "6.2.8",
     "pg-introspection": "file:vendor/crystal-3109/pg-introspection-1.0.1.tgz",
     "pg-sql2": "file:vendor/crystal-3109/pg-sql2-5.0.1.tgz",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,202 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 11.0.8
+        version: 11.0.8
+      pnpm:
+        specifier: 11.0.8
+        version: 11.0.8
+
+packages:
+
+  '@pnpm/exe@11.0.8':
+    resolution: {integrity: sha512-TZAT5GddIropl7vXbGh+y4uIlPYUy0+i9DK4GGX2XTM4qvyICUfrAs3Hg574jbSM0RR9CCfHL78A0frQro44tw==}
+    hasBin: true
+
+  '@pnpm/linux-arm64@11.0.8':
+    resolution: {integrity: sha512-eJrvyl7ZK0IEHnO5Kot5/e95a0HytTPfqz8phJcIXbLKopSZXQoklp2GBu8oKBmHbGYypre+fJbgrXaS+7UwNw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pnpm/linux-x64@11.0.8':
+    resolution: {integrity: sha512-jrzzkskNRPyJvKeeJnxVNVrDWac8yUUOKu645WB8I+2zW2WjYhqPIJjHJ9BrC9zCYL1+oFrg9+hCu85+YVtLaQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@pnpm/linuxstatic-arm64@11.0.8':
+    resolution: {integrity: sha512-+2Pi32x8/VZHNP2F9KQKKO2ND/lYUzOAVyp/z0J9CmIZF8DXEg+iPkw0h+By8TTu+Bd1ocqViiM67vYeuxBvvw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/linuxstatic-x64@11.0.8':
+    resolution: {integrity: sha512-0yRf1peDuZdDfowh2OSk+KMc/fkK+ftM605S3CpCa7P3DbTw49AV7biyqeLsVdioB9dCv15XC690jLio3VAUUw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/macos-arm64@11.0.8':
+    resolution: {integrity: sha512-McMGN+OCNhhXjoySjtsWkEKWaT3YouV87+HvJi6P2Ww5VKu9TWVaIm0gPkwTOdiTDm1nUHvbFENzT9f7lWelFA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/win-arm64@11.0.8':
+    resolution: {integrity: sha512-UqaMayR9fxqsngebohEgZ68dwktHV/ZS3eEKgVbcJOzM91iLsuy5rA/1p7STptEM3iVOwuNH7bRvb6JEouCbrA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/win-x64@11.0.8':
+    resolution: {integrity: sha512-nrnQSDI1LTa9OR5TNcOnYA+6fhc31R62YupYpOxTVBOU8XxSFm7BxCX8KHn3h9S5HNrgPhWq1+bO5G/DlNGmDw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink@0.1.19':
+    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
+    engines: {node: '>= 10'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  pnpm@11.0.8:
+    resolution: {integrity: sha512-TECX4d0tQjcsTn+lp5H/KPx1pITHrBkuZLHfD97xdZS6mC+bT+2a37PHV4RvVlt5mydj+zcz0d4by4LPRmhJEg==}
+    engines: {node: '>=22.13'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe@11.0.8':
+    dependencies:
+      '@reflink/reflink': 0.1.19
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@pnpm/linux-arm64': 11.0.8
+      '@pnpm/linux-x64': 11.0.8
+      '@pnpm/linuxstatic-arm64': 11.0.8
+      '@pnpm/linuxstatic-x64': 11.0.8
+      '@pnpm/macos-arm64': 11.0.8
+      '@pnpm/win-arm64': 11.0.8
+      '@pnpm/win-x64': 11.0.8
+
+  '@pnpm/linux-arm64@11.0.8':
+    optional: true
+
+  '@pnpm/linux-x64@11.0.8':
+    optional: true
+
+  '@pnpm/linuxstatic-arm64@11.0.8':
+    optional: true
+
+  '@pnpm/linuxstatic-x64@11.0.8':
+    optional: true
+
+  '@pnpm/macos-arm64@11.0.8':
+    optional: true
+
+  '@pnpm/win-arm64@11.0.8':
+    optional: true
+
+  '@pnpm/win-x64@11.0.8':
+    optional: true
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink@0.1.19':
+    optionalDependencies:
+      '@reflink/reflink-darwin-arm64': 0.1.19
+      '@reflink/reflink-darwin-x64': 0.1.19
+      '@reflink/reflink-linux-arm64-gnu': 0.1.19
+      '@reflink/reflink-linux-arm64-musl': 0.1.19
+      '@reflink/reflink-linux-x64-gnu': 0.1.19
+      '@reflink/reflink-linux-x64-musl': 0.1.19
+      '@reflink/reflink-win32-arm64-msvc': 0.1.19
+      '@reflink/reflink-win32-x64-msvc': 0.1.19
+
+  detect-libc@2.1.2: {}
+
+  pnpm@11.0.8: {}
+
+---
 lockfileVersion: '9.0'
 
 settings:
@@ -44,6 +243,9 @@ importers:
       graphile-config:
         specifier: file:vendor/crystal-3109/graphile-config-1.1.0.tgz
         version: file:vendor/crystal-3109/graphile-config-1.1.0.tgz
+      graphql:
+        specifier: 16.14.2
+        version: 16.14.2
       jose:
         specifier: 6.2.8
         version: 6.2.8

--- a/src/presets/turnstile.ts
+++ b/src/presets/turnstile.ts
@@ -1,3 +1,5 @@
+import { Kind, parse } from 'graphql'
+import type { OperationDefinitionNode } from 'graphql'
 import type { ProcessGraphQLRequestBodyEvent } from 'postgraphile/grafserv'
 
 const IS_DEV = process.env['NODE_ENV'] !== 'production'
@@ -19,6 +21,35 @@ const setStatusCode = (
   if (requestContext?.node?.res) {
     requestContext.node.res.statusCode = statusCode
   }
+}
+
+// Determines whether the resolved operation is a plain query, purely from the document's syntax (query/mutation/subscription keyword).
+// Anything ambiguous or unparseable is treated as not a query, so verification is still requested when unsure.
+const isQueryOnlyRequest = (event: ProcessGraphQLRequestBodyEvent) => {
+  const { operationName, query } = event.body
+
+  if (typeof query !== 'string') return false
+
+  let operations: OperationDefinitionNode[]
+  try {
+    operations = parse(query).definitions.filter(
+      (definition): definition is OperationDefinitionNode =>
+        definition.kind === Kind.OPERATION_DEFINITION,
+    )
+  } catch {
+    return false
+  }
+
+  const operation =
+    typeof operationName === 'string'
+      ? operations.find(
+          (definition) => definition.name?.value === operationName,
+        )
+      : operations.length === 1
+        ? operations[0]
+        : undefined
+
+  return operation?.operation === 'query'
 }
 
 const TurnstilePlugin: GraphileConfig.Plugin = {
@@ -44,7 +75,11 @@ const TurnstilePlugin: GraphileConfig.Plugin = {
           return next()
         }
 
-        // TODO: only test turnstile for certain operations, e.g. authentication and account registration
+        if (isQueryOnlyRequest(event)) {
+          logger.debug('Skipping verification for a query-only request.')
+          return next()
+        }
+
         const key = event.request.getHeader('x-turnstile-key')
         const verificationTimeoutMs = 5000
         const controller = new AbortController()


### PR DESCRIPTION
Optimizes Turnstile verification by ensuring it is only applied to GraphQL requests that involve mutations. This change introduces a mechanism to parse incoming GraphQL requests and identify if they consist solely of query operations.

- Skips Turnstile verification for read-only GraphQL queries.
- Improves performance and reduces latency for queries by avoiding unnecessary external verification calls.
- Continues to apply Turnstile verification for mutations and any ambiguous operations to maintain security for data-modifying actions.