### PR TITLE
feat(turnstile)!: protect by smart tag

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
-node_modules
+.claude
 .eslintcache
+.worktrees
+node_modules

--- a/.github/smoke-test.sh
+++ b/.github/smoke-test.sh
@@ -63,6 +63,7 @@ echo "::group::Set up database schema"
 docker exec "$CONTAINER_DB" psql -U postgres -d postgraphile -c '
   CREATE SCHEMA vibetype;
   CREATE TABLE vibetype.account (id serial PRIMARY KEY);
+  COMMENT ON TABLE vibetype.account IS $$@turnstileProtected$$;
 '
 echo "Schema ready."
 echo "::endgroup::"
@@ -73,7 +74,9 @@ chmod 755 "$ENV_DIR"
 
 echo "postgresql://postgres:postgres@${CONTAINER_DB}:5432/postgraphile" > "$ENV_DIR/POSTGRAPHILE_CONNECTION"
 echo "postgresql://postgres:postgres@${CONTAINER_DB}:5432/postgraphile" > "$ENV_DIR/POSTGRAPHILE_OWNER_CONNECTION"
-echo "true" > "$ENV_DIR/TURNSTILE_BYPASS"
+# Cloudflare's documented "always fails" test secret.
+# Running with a real secret rather than TURNSTILE_BYPASS is what keeps the verification path covered at all; the token check below rejects before any call to Cloudflare is made, so this needs no network egress.
+echo "2x0000000000000000000000000000000AA" > "$ENV_DIR/TURNSTILE_SECRET_KEY"
 cp private.pem "$ENV_DIR/POSTGRAPHILE_JWT_SECRET_KEY"
 cp public.pem "$ENV_DIR/POSTGRAPHILE_JWT_PUBLIC_KEY"
 
@@ -144,6 +147,31 @@ echo "$RESPONSE" | jq -e '(.data.allAccounts.totalCount | type) == "number" and 
   exit 1
 }
 echo "Smoke test OK."
+echo "::endgroup::"
+
+echo "::group::Turnstile"
+# vibetype.account carries the '@turnstileProtected' tag, so its mutations must be rejected outright when no token is presented, while queries (asserted above) stay unaffected.
+RESPONSE=$(curl -sS --max-time 10 -w '\n%{http_code}' -X POST "http://localhost:${HOST_PORT}/graphql" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"mutation { createAccount(input: {account: {}}) { clientMutationId } }"}') || {
+  echo "Request failed, container logs:"
+  docker logs "$CONTAINER"
+  exit 1
+}
+STATUS_CODE="$(echo "$RESPONSE" | tail -1)"
+BODY="$(echo "$RESPONSE" | sed '$d')"
+echo "Response: $STATUS_CODE $BODY"
+if [ "$STATUS_CODE" != "422" ]; then
+  echo "Expected HTTP 422 for a protected mutation without a token, container logs:"
+  docker logs "$CONTAINER"
+  exit 1
+fi
+echo "$BODY" | jq -e '.errors[0].message == "Turnstile token not provided"' || {
+  echo "Response assertion failed, container logs:"
+  docker logs "$CONTAINER"
+  exit 1
+}
+echo "Turnstile test OK."
 echo "::endgroup::"
 
 echo "::group::Container logs"

--- a/src/presets/graphqlOperation.ts
+++ b/src/presets/graphqlOperation.ts
@@ -1,4 +1,4 @@
-import { Kind, parse } from 'graphql'
+import { getOperationAST, parse } from 'graphql'
 import type { DocumentNode, OperationDefinitionNode } from 'graphql'
 import type { ProcessGraphQLRequestBodyEvent } from 'postgraphile/grafserv'
 
@@ -7,59 +7,54 @@ export interface ResolvedOperation {
   operation: OperationDefinitionNode
 }
 
-// Multiple middleware (turnstile, passwordStrength) resolve the operation for the same
-// request; caching by event avoids parsing the query more than once per request.
-const resolutionCache = new WeakMap<
-  ProcessGraphQLRequestBodyEvent,
-  ResolvedOperation | undefined
->()
+const PARSE_CACHE_MAX_SIZE = 50
+const PARSE_ERROR = Symbol('graphql-operation-parse-error')
+const parseCache = new Map<string, DocumentNode | typeof PARSE_ERROR>()
+
+// grafserv's own `parseAndValidate` (see `node_modules/grafserv/dist/middleware/graphql.js`) parses and caches the query too, but that happens downstream of the `processGraphQLRequestBody` middleware this module serves, so we can't share its cache.
+// Memoizing here instead of per request means repeat visitors of the same query text don't pay for a parse at all, which also covers the case the previous per-event WeakMap existed for: several middleware resolving the operation of one request.
+const parseWithCache = (query: string): DocumentNode | typeof PARSE_ERROR => {
+  const cached = parseCache.get(query)
+  if (cached !== undefined) {
+    // Refresh recency so frequently-seen queries survive eviction.
+    parseCache.delete(query)
+    parseCache.set(query, cached)
+    return cached
+  }
+
+  let parsed: DocumentNode | typeof PARSE_ERROR
+  try {
+    parsed = parse(query)
+  } catch {
+    parsed = PARSE_ERROR
+  }
+
+  parseCache.set(query, parsed)
+  if (parseCache.size > PARSE_CACHE_MAX_SIZE) {
+    const oldestKey = parseCache.keys().next().value
+    if (oldestKey !== undefined) parseCache.delete(oldestKey)
+  }
+
+  return parsed
+}
 
 // Resolves the operation a request will execute, purely from the document's syntax.
+// `getOperationAST` is what the GraphQL executor itself uses to pick the operation, so a caller can rely on this being the operation that actually runs rather than an approximation of it.
 // Returns undefined for anything ambiguous or unparseable, so callers can fail safe.
 export const resolveOperation = (
   event: ProcessGraphQLRequestBodyEvent,
 ): ResolvedOperation | undefined => {
-  if (resolutionCache.has(event)) return resolutionCache.get(event)
-
   const { operationName, query } = event.body
 
-  const resolved = ((): ResolvedOperation | undefined => {
-    if (typeof query !== 'string') return undefined
+  if (typeof query !== 'string') return undefined
 
-    let document: DocumentNode
-    try {
-      document = parse(query)
-    } catch {
-      return undefined
-    }
+  const document = parseWithCache(query)
+  if (document === PARSE_ERROR) return undefined
 
-    const operations = document.definitions.filter(
-      (definition): definition is OperationDefinitionNode =>
-        definition.kind === Kind.OPERATION_DEFINITION,
-    )
+  const operation = getOperationAST(
+    document,
+    typeof operationName === 'string' ? operationName : undefined,
+  )
 
-    const operation =
-      typeof operationName === 'string'
-        ? operations.find(
-            (definition) => definition.name?.value === operationName,
-          )
-        : operations.length === 1
-          ? operations[0]
-          : undefined
-
-    return operation && { document, operation }
-  })()
-
-  resolutionCache.set(event, resolved)
-  return resolved
-}
-
-export const setStatusCode = (
-  event: ProcessGraphQLRequestBodyEvent,
-  statusCode: number,
-) => {
-  const requestContext = event.request?.requestContext
-  if (requestContext?.node?.res) {
-    requestContext.node.res.statusCode = statusCode
-  }
+  return operation ? { document, operation } : undefined
 }

--- a/src/presets/passwordStrength.ts
+++ b/src/presets/passwordStrength.ts
@@ -10,7 +10,9 @@ import type {
   SelectionSetNode,
 } from 'graphql'
 
-import { resolveOperation, setStatusCode } from './graphqlOperation.ts'
+import { SafeError } from 'postgraphile/grafast'
+
+import { resolveOperation } from './graphqlOperation.ts'
 
 const { ZxcvbnFactory } = ZxcvbnCore
 
@@ -181,9 +183,8 @@ const PasswordStrengthPlugin: GraphileConfig.Plugin = {
         for (const password of passwords) {
           const { score } = zxcvbn.check(password)
           if (score < PASSWORD_SCORE_MINIMUM) {
-            setStatusCode(event, 422)
-
-            throw new Error('Password is too weak')
+            // Only a `SafeError` keeps its status code and message on the way out: grafserv replaces every other throw from this hook with a generic `400 Parsing failed`, which would leave the client unable to tell a weak password from a malformed request.
+            throw new SafeError('Password is too weak', { statusCode: 422 })
           }
         }
 

--- a/src/presets/turnstile.ts
+++ b/src/presets/turnstile.ts
@@ -4,6 +4,7 @@ import type {
   FragmentDefinitionNode,
   SelectionSetNode,
 } from 'graphql'
+import { SafeError } from 'postgraphile/grafast'
 import type { ProcessGraphQLRequestBodyEvent } from 'postgraphile/grafserv'
 
 const IS_DEV = process.env['NODE_ENV'] !== 'production'
@@ -14,7 +15,7 @@ const TURNSTILE_SITEVERIFY_URL =
 
 if (!TURNSTILE_SECRET_KEY && !TURNSTILE_BYPASS) {
   throw new Error(
-    'TURNSTILE_SECRET_KEY is required unless TURNSTILE_BYPASS is set.',
+    'TURNSTILE_SECRET_KEY is required unless TURNSTILE_BYPASS is set to the exact string `true`.',
   )
 }
 
@@ -33,60 +34,38 @@ const logger = {
     console.error(`[turnstile] ${message}`, data)
   },
 }
-const setStatusCode = (
-  event: ProcessGraphQLRequestBodyEvent,
-  statusCode: number,
-) => {
-  const requestContext = event.request?.requestContext
-  if (requestContext?.node?.res) {
-    requestContext.node.res.statusCode = statusCode
-  }
-}
 
 declare global {
-  // Ambient module augmentation requires a `declare global { namespace ... }`
-  // block; there is no ES module equivalent for extending third-party types.
+  // Ambient module augmentation requires a `declare global { namespace ... }` block; there is no ES module equivalent for extending third-party types.
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace GraphileBuild {
     interface Build {
-      // Populated once per schema build (see the `build` and
-      // `GraphQLObjectType_fields_field` hooks below) with the GraphQL field
-      // names of root Mutation fields whose underlying Postgres resource
-      // (custom function or table) carries the `@turnstileProtected` smart
-      // comment tag.
-      // This is the single source of truth for which mutations require
-      // Turnstile verification; the tag travels with the resource itself,
-      // so a rename doesn't silently drop protection.
+      // Populated once per schema build (see the `init` and `GraphQLObjectType_fields_field` hooks below) with the GraphQL field names of root Mutation fields whose underlying Postgres resource (custom function or table) carries the `@turnstileProtected` smart comment tag.
+      // This is the single source of truth for which mutations require Turnstile verification; the tag travels with the resource itself, so a rename doesn't silently drop protection.
       turnstileProtectedFieldNames: Set<string>
+      // Resources carrying the tag that have not (yet) contributed a field name to the Set above.
+      // Whatever is left in here when the schema is finalized is a tag that silently does nothing, which is worth shouting about.
+      turnstilePendingTaggedResources: Set<
+        GraphileBuild.Build['pgResources'][string]
+      >
     }
   }
 }
 
-// `processGraphQLRequestBody` (below) runs ahead of grafast's schema-aware
-// request pipeline, so it has no direct handle on the `build` object that
-// produced the currently-serving schema; grafserv's
-// `ProcessGraphQLRequestBodyEvent` only exposes `resolvedPreset`, `body`,
-// `request` and `graphqlWsContext`, none of which reach back to `build`.
-// We mirror the build-scoped Set here with a single atomic pointer swap once
-// a schema build finishes (see the `finalize` hook below), so a concurrent
-// request can never observe a half-populated Set the way the previous
-// clear()-then-repopulate-in-place implementation could under watch-mode
-// hot reload. This doesn't give each in-flight request a pin to the exact
-// schema build it started against (grafserv's API doesn't expose that), so
-// a request that started just before a hot reload could still observe the
-// new build's Set; that's an inherent limitation of this plugin operating
-// outside grafserv's schema-aware pipeline, not something fixable from here.
+// `processGraphQLRequestBody` (below) runs ahead of grafast's schema-aware request pipeline, so it has no direct handle on the `build` object that produced the currently-serving schema; grafserv's `ProcessGraphQLRequestBodyEvent` only exposes `resolvedPreset`, `body`, `request` and `graphqlWsContext`, none of which reach back to `build`.
+// We mirror the build-scoped Set here with a single atomic pointer swap once a schema build finishes (see the `finalize` hook below), so a concurrent request can never observe a half-populated Set the way the previous clear()-then-repopulate-in-place implementation could under watch-mode hot reload.
+// This doesn't give each in-flight request a pin to the exact schema build it started against (grafserv's API doesn't expose that), so a request that started just before a hot reload could still observe the new build's Set; that's an inherent limitation of this plugin operating outside grafserv's schema-aware pipeline, not something fixable from here.
 let currentTurnstileProtectedFieldNames = new Set<string>()
+
+// grafserv installs its GraphQL handler as soon as the *preset* resolves, which is well before the first schema build finishes; with `retryOnInitFail` and a slow Postgres that gap is seconds to minutes after every restart.
+// During that window the Set above is simply empty, which must not be mistaken for "nothing is protected", so we fail closed until a build has actually published its names.
+let hasPublishedTurnstileProtectedFieldNames = false
 
 const PARSE_CACHE_MAX_SIZE = 50
 const PARSE_ERROR = Symbol('turnstile-parse-error')
 const parseCache = new Map<string, DocumentNode | typeof PARSE_ERROR>()
 
-// grafserv's own `parseAndValidate` (see
-// `node_modules/grafserv/dist/middleware/graphql.js`) parses and caches the
-// query too, but that happens downstream of this hook, so we can't share
-// its cache; memoize our own parse here instead of re-parsing the same
-// query text on every request.
+// grafserv's own `parseAndValidate` (see `node_modules/grafserv/dist/middleware/graphql.js`) parses and caches the query too, but that happens downstream of this hook, so we can't share its cache; memoize our own parse here instead of re-parsing the same query text on every request.
 const parseWithCache = (query: string): DocumentNode | typeof PARSE_ERROR => {
   const cached = parseCache.get(query)
   if (cached !== undefined) {
@@ -176,9 +155,12 @@ const requiresTurnstileVerification = (
   )
 
   if (!operation) return true
-  // Only plain queries are exempt; both mutations and subscriptions can
-  // invoke protected fields and must be checked.
+  // Only plain queries are exempt.
+  // Whether an operation is a query is decided by the document's syntax alone, so this verdict holds even before a schema exists.
   if (operation.operation === 'query') return false
+
+  // Everything below needs to know which fields are protected, so without a published Set there is nothing to decide against.
+  if (!hasPublishedTurnstileProtectedFieldNames) return true
 
   const fragmentsByName = new Map(
     document.definitions
@@ -202,35 +184,43 @@ const TurnstilePlugin: GraphileConfig.Plugin = {
   version: '0.0.0',
   schema: {
     hooks: {
-      // Root mutation fields backed by a custom function don't carry their pgResource in field scope (only computed columns and connection/list fields do), so instead of hooking each field, walk build.pgResources directly here: every resource tagged '@turnstileProtected' that's a mutation gets its final GraphQL field name computed via the same inflector graphile-build-pg itself uses to name that field, so this stays correct regardless of naming config.
+      // `build` is frozen the moment its hooks have run, so the Sets the later hooks fill have to be created here.
       build(build) {
-        const protectedFieldNames = new Set<string>()
+        build.turnstileProtectedFieldNames = new Set()
+        build.turnstilePendingTaggedResources = new Set()
 
+        return build
+      },
+      // Root mutation fields backed by a custom function don't carry their pgResource in field scope (only computed columns and connection/list fields do), so instead of hooking each field, walk build.pgResources directly here; the field name comes from the same inflector graphile-build-pg itself uses to name that field, so this stays correct regardless of naming config.
+      // Whether such a function is exposed under `Mutation` at all is decided by `pgResourceMatches(resource, 'mutationField')`, not by `resource.isMutation` (which merely feeds that behavior's default, so a `@behavior mutationField` tag can expose a resource the flag says nothing about); `build.behavior` only exists once the `build` phase is over, hence `init` rather than `build`.
+      init(_, build) {
         type MutationResource = Parameters<
           typeof build.inflection.customMutationField
         >[0]['resource']
 
         for (const resourceName in build.pgResources) {
-          const resource = build.pgResources[resourceName] as MutationResource
+          const resource = build.pgResources[resourceName]
+
+          if (!resource?.extensions?.tags?.['turnstileProtected']) continue
+
+          build.turnstilePendingTaggedResources.add(resource)
 
           if (
-            resource.isMutation &&
-            resource.extensions?.tags?.['turnstileProtected']
+            resource.parameters &&
+            build.behavior.pgResourceMatches(resource, 'mutationField')
           ) {
-            protectedFieldNames.add(
-              build.inflection.customMutationField({ resource }),
+            build.turnstileProtectedFieldNames.add(
+              build.inflection.customMutationField({
+                resource: resource as MutationResource,
+              }),
             )
+            build.turnstilePendingTaggedResources.delete(resource)
           }
         }
 
-        build.turnstileProtectedFieldNames = protectedFieldNames
-
-        return build
+        return _
       },
-      // Table-backed CRUD mutations (createX/updateX/deleteX) always carry
-      // their originating `pgResource` in field scope, unlike the
-      // custom-function mutations handled above, so they're identified
-      // directly here instead of via inflector-based name guessing.
+      // Table-backed CRUD mutations (createX/updateX/deleteX) always carry their originating `pgResource` in field scope, unlike the custom-function mutations handled above, so they're identified directly here instead of via inflector-based name guessing.
       GraphQLObjectType_fields_field(field, build, context) {
         const { scope } = context
 
@@ -242,14 +232,27 @@ const TurnstilePlugin: GraphileConfig.Plugin = {
           scope.pgFieldResource?.extensions?.tags?.['turnstileProtected']
         ) {
           build.turnstileProtectedFieldNames.add(scope.fieldName)
+          build.turnstilePendingTaggedResources.delete(scope.pgFieldResource)
         }
 
         return field
       },
       finalize(schema, build) {
-        // Publish the fully-populated Set in one atomic pointer swap; see
-        // the comment on `currentTurnstileProtectedFieldNames` above.
-        currentTurnstileProtectedFieldNames = build.turnstileProtectedFieldNames
+        // The hook above only runs for the Mutation type once graphql-js forces that type's lazy `fields` thunk, which it would otherwise not do until `validateSchema` runs downstream of this hook.
+        // Forcing it here is what makes the Set genuinely complete at this point, rather than one that merely gains the table-backed CRUD names moments later through a shared reference.
+        schema.getMutationType()?.getFields()
+
+        for (const resource of build.turnstilePendingTaggedResources) {
+          logger.error(
+            `The '@turnstileProtected' tag on '${resource.name}' has no effect: the resource exposes no root mutation field. Only mutations can be protected.`,
+          )
+        }
+
+        // Publish in one atomic pointer swap; see the comment on `currentTurnstileProtectedFieldNames` above.
+        currentTurnstileProtectedFieldNames = new Set(
+          build.turnstileProtectedFieldNames,
+        )
+        hasPublishedTurnstileProtectedFieldNames = true
 
         return schema
       },
@@ -285,10 +288,12 @@ const TurnstilePlugin: GraphileConfig.Plugin = {
         const token = event.request.getHeader('x-turnstile-key')
         logger.debug('Received Turnstile token', { present: Boolean(token) })
 
+        // Only a `SafeError` keeps its status code and message on the way out: grafserv replaces every other throw from this hook with a generic `400 Parsing failed`, which would leave the client unable to tell "re-run the challenge" from "my request was malformed".
         if (!token) {
           logger.error('No Turnstile token provided.')
-          setStatusCode(event, 422)
-          throw new Error('Turnstile token not provided')
+          throw new SafeError('Turnstile token not provided', {
+            statusCode: 422,
+          })
         }
 
         const verificationTimeoutMs = 5000
@@ -297,70 +302,69 @@ const TurnstilePlugin: GraphileConfig.Plugin = {
           () => controller.abort(),
           verificationTimeoutMs,
         )
-        let result: Response
+        const requestFailure = (error: unknown) =>
+          error instanceof Error &&
+          (error.name === 'AbortError' || controller.signal.aborted)
+            ? new SafeError(
+                'Turnstile verification timed out',
+                { statusCode: 504 },
+                { cause: error },
+              )
+            : new SafeError(
+                'Turnstile verification service unavailable',
+                { statusCode: 503 },
+                { cause: error },
+              )
+        let verification: TurnstileSiteverifyResponse
 
+        // The timeout has to stay armed until the response body has been read, not just until its headers arrive: the body is read through the same abort signal, and clearing the timer early would let a stalled body pin this request, its socket and its pool slot open indefinitely.
         try {
-          result = await fetch(TURNSTILE_SITEVERIFY_URL, {
-            body: new URLSearchParams({
-              response: token,
-              secret: TURNSTILE_SECRET_KEY ?? '',
-            }),
-            method: 'POST',
-            signal: controller.signal,
-          })
-        } catch (error) {
-          logger.error('Verification request failed', error)
+          let result: Response
 
-          if (
-            error instanceof Error &&
-            (error.name === 'AbortError' || controller.signal.aborted)
-          ) {
-            setStatusCode(event, 504)
-            throw new Error('Turnstile verification timed out', {
-              cause: error,
+          try {
+            result = await fetch(TURNSTILE_SITEVERIFY_URL, {
+              body: new URLSearchParams({
+                response: token,
+                secret: TURNSTILE_SECRET_KEY ?? '',
+              }),
+              method: 'POST',
+              signal: controller.signal,
+            })
+          } catch (error) {
+            logger.error('Verification request failed', error)
+            throw requestFailure(error)
+          }
+
+          if (!result.ok) {
+            logger.error('Verification service returned an error', {
+              status: result.status,
+              statusText: result.statusText,
+            })
+            throw new SafeError('Turnstile verification service unavailable', {
+              statusCode: 503,
             })
           }
 
-          setStatusCode(event, 503)
-          throw new Error('Turnstile verification service unavailable', {
-            cause: error,
-          })
+          try {
+            verification = (await result.json()) as TurnstileSiteverifyResponse
+          } catch (error) {
+            logger.error('Verification response could not be read', error)
+            throw requestFailure(error)
+          }
         } finally {
           clearTimeout(timeout)
         }
 
-        if (!result.ok) {
-          logger.error('Verification service returned an error', {
-            status: result.status,
-            statusText: result.statusText,
-          })
-          setStatusCode(event, 503)
-          throw new Error('Turnstile verification service unavailable')
-        }
-
-        let verification: TurnstileSiteverifyResponse
-
-        try {
-          verification = (await result.json()) as TurnstileSiteverifyResponse
-        } catch (error) {
-          logger.error('Verification response could not be parsed', error)
-          setStatusCode(event, 503)
-          throw new Error('Turnstile verification service unavailable', {
-            cause: error,
-          })
-        }
-
-        if (IS_DEV) {
-          logger.debug('Verification response', verification)
-        }
+        logger.debug('Verification response', verification)
 
         if (!verification.success) {
           logger.error('Verification failed', {
             errorCodes: verification['error-codes'],
           })
-          setStatusCode(event, 401)
 
-          throw new Error('Turnstile verification failed')
+          throw new SafeError('Turnstile verification failed', {
+            statusCode: 401,
+          })
         }
 
         logger.debug('Verification succeeded')

--- a/src/presets/turnstile.ts
+++ b/src/presets/turnstile.ts
@@ -1,11 +1,9 @@
-import { Kind, getOperationAST, parse } from 'graphql'
-import type {
-  DocumentNode,
-  FragmentDefinitionNode,
-  SelectionSetNode,
-} from 'graphql'
+import { Kind } from 'graphql'
+import type { FragmentDefinitionNode, SelectionSetNode } from 'graphql'
 import { SafeError } from 'postgraphile/grafast'
 import type { ProcessGraphQLRequestBodyEvent } from 'postgraphile/grafserv'
+
+import { resolveOperation } from './graphqlOperation.ts'
 
 const IS_DEV = process.env['NODE_ENV'] !== 'production'
 const TURNSTILE_BYPASS = process.env['TURNSTILE_BYPASS'] === 'true'
@@ -61,36 +59,6 @@ let currentTurnstileProtectedFieldNames = new Set<string>()
 // During that window the Set above is simply empty, which must not be mistaken for "nothing is protected", so we fail closed until a build has actually published its names.
 let hasPublishedTurnstileProtectedFieldNames = false
 
-const PARSE_CACHE_MAX_SIZE = 50
-const PARSE_ERROR = Symbol('turnstile-parse-error')
-const parseCache = new Map<string, DocumentNode | typeof PARSE_ERROR>()
-
-// grafserv's own `parseAndValidate` (see `node_modules/grafserv/dist/middleware/graphql.js`) parses and caches the query too, but that happens downstream of this hook, so we can't share its cache; memoize our own parse here instead of re-parsing the same query text on every request.
-const parseWithCache = (query: string): DocumentNode | typeof PARSE_ERROR => {
-  const cached = parseCache.get(query)
-  if (cached !== undefined) {
-    // Refresh recency so frequently-seen queries survive eviction.
-    parseCache.delete(query)
-    parseCache.set(query, cached)
-    return cached
-  }
-
-  let parsed: DocumentNode | typeof PARSE_ERROR
-  try {
-    parsed = parse(query)
-  } catch {
-    parsed = PARSE_ERROR
-  }
-
-  parseCache.set(query, parsed)
-  if (parseCache.size > PARSE_CACHE_MAX_SIZE) {
-    const oldestKey = parseCache.keys().next().value
-    if (oldestKey !== undefined) parseCache.delete(oldestKey)
-  }
-
-  return parsed
-}
-
 // Recursively resolves the field names actually selected by a selection set, expanding fragment spreads and inline fragments.
 // A security check based only on direct field selections could be bypassed by wrapping a protected field call in a fragment.
 const collectFieldNames = (
@@ -142,28 +110,18 @@ const collectFieldNames = (
 const requiresTurnstileVerification = (
   event: ProcessGraphQLRequestBodyEvent,
 ) => {
-  const { operationName, query } = event.body
+  const resolved = resolveOperation(event)
 
-  if (typeof query !== 'string') return true
-
-  const document = parseWithCache(query)
-  if (document === PARSE_ERROR) return true
-
-  const operation = getOperationAST(
-    document,
-    typeof operationName === 'string' ? operationName : undefined,
-  )
-
-  if (!operation) return true
+  if (!resolved) return true
   // Only plain queries are exempt.
   // Whether an operation is a query is decided by the document's syntax alone, so this verdict holds even before a schema exists.
-  if (operation.operation === 'query') return false
+  if (resolved.operation.operation === 'query') return false
 
   // Everything below needs to know which fields are protected, so without a published Set there is nothing to decide against.
   if (!hasPublishedTurnstileProtectedFieldNames) return true
 
   const fragmentsByName = new Map(
-    document.definitions
+    resolved.document.definitions
       .filter(
         (definition): definition is FragmentDefinitionNode =>
           definition.kind === Kind.FRAGMENT_DEFINITION,
@@ -171,7 +129,10 @@ const requiresTurnstileVerification = (
       .map((definition) => [definition.name.value, definition] as const),
   )
 
-  const fieldNames = collectFieldNames(fragmentsByName, operation.selectionSet)
+  const fieldNames = collectFieldNames(
+    fragmentsByName,
+    resolved.operation.selectionSet,
+  )
   for (const fieldName of fieldNames) {
     if (currentTurnstileProtectedFieldNames.has(fieldName)) return true
   }

--- a/src/presets/turnstile.ts
+++ b/src/presets/turnstile.ts
@@ -1,8 +1,28 @@
+import { Kind, getOperationAST, parse } from 'graphql'
+import type {
+  DocumentNode,
+  FragmentDefinitionNode,
+  SelectionSetNode,
+} from 'graphql'
 import type { ProcessGraphQLRequestBodyEvent } from 'postgraphile/grafserv'
 
-import { resolveOperation, setStatusCode } from './graphqlOperation.ts'
-
 const IS_DEV = process.env['NODE_ENV'] !== 'production'
+const TURNSTILE_BYPASS = process.env['TURNSTILE_BYPASS'] === 'true'
+const TURNSTILE_SECRET_KEY = process.env['TURNSTILE_SECRET_KEY']
+const TURNSTILE_SITEVERIFY_URL =
+  'https://challenges.cloudflare.com/turnstile/v0/siteverify'
+
+if (!TURNSTILE_SECRET_KEY && !TURNSTILE_BYPASS) {
+  throw new Error(
+    'TURNSTILE_SECRET_KEY is required unless TURNSTILE_BYPASS is set.',
+  )
+}
+
+interface TurnstileSiteverifyResponse {
+  success: boolean
+  'error-codes'?: string[]
+}
+
 const logger = {
   debug: (message: string, data?: unknown) => {
     if (IS_DEV) {
@@ -13,15 +33,228 @@ const logger = {
     console.error(`[turnstile] ${message}`, data)
   },
 }
+const setStatusCode = (
+  event: ProcessGraphQLRequestBodyEvent,
+  statusCode: number,
+) => {
+  const requestContext = event.request?.requestContext
+  if (requestContext?.node?.res) {
+    requestContext.node.res.statusCode = statusCode
+  }
+}
 
-// Determines whether the resolved operation is a plain query, purely from the document's syntax (query/mutation/subscription keyword).
-// Anything ambiguous or unparseable is treated as not a query, so verification is still requested when unsure.
-const isQueryOnlyRequest = (event: ProcessGraphQLRequestBodyEvent) =>
-  resolveOperation(event)?.operation.operation === 'query'
+declare global {
+  // Ambient module augmentation requires a `declare global { namespace ... }`
+  // block; there is no ES module equivalent for extending third-party types.
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace GraphileBuild {
+    interface Build {
+      // Populated once per schema build (see the `build` and
+      // `GraphQLObjectType_fields_field` hooks below) with the GraphQL field
+      // names of root Mutation fields whose underlying Postgres resource
+      // (custom function or table) carries the `@turnstileProtected` smart
+      // comment tag.
+      // This is the single source of truth for which mutations require
+      // Turnstile verification; the tag travels with the resource itself,
+      // so a rename doesn't silently drop protection.
+      turnstileProtectedFieldNames: Set<string>
+    }
+  }
+}
+
+// `processGraphQLRequestBody` (below) runs ahead of grafast's schema-aware
+// request pipeline, so it has no direct handle on the `build` object that
+// produced the currently-serving schema; grafserv's
+// `ProcessGraphQLRequestBodyEvent` only exposes `resolvedPreset`, `body`,
+// `request` and `graphqlWsContext`, none of which reach back to `build`.
+// We mirror the build-scoped Set here with a single atomic pointer swap once
+// a schema build finishes (see the `finalize` hook below), so a concurrent
+// request can never observe a half-populated Set the way the previous
+// clear()-then-repopulate-in-place implementation could under watch-mode
+// hot reload. This doesn't give each in-flight request a pin to the exact
+// schema build it started against (grafserv's API doesn't expose that), so
+// a request that started just before a hot reload could still observe the
+// new build's Set; that's an inherent limitation of this plugin operating
+// outside grafserv's schema-aware pipeline, not something fixable from here.
+let currentTurnstileProtectedFieldNames = new Set<string>()
+
+const PARSE_CACHE_MAX_SIZE = 50
+const PARSE_ERROR = Symbol('turnstile-parse-error')
+const parseCache = new Map<string, DocumentNode | typeof PARSE_ERROR>()
+
+// grafserv's own `parseAndValidate` (see
+// `node_modules/grafserv/dist/middleware/graphql.js`) parses and caches the
+// query too, but that happens downstream of this hook, so we can't share
+// its cache; memoize our own parse here instead of re-parsing the same
+// query text on every request.
+const parseWithCache = (query: string): DocumentNode | typeof PARSE_ERROR => {
+  const cached = parseCache.get(query)
+  if (cached !== undefined) {
+    // Refresh recency so frequently-seen queries survive eviction.
+    parseCache.delete(query)
+    parseCache.set(query, cached)
+    return cached
+  }
+
+  let parsed: DocumentNode | typeof PARSE_ERROR
+  try {
+    parsed = parse(query)
+  } catch {
+    parsed = PARSE_ERROR
+  }
+
+  parseCache.set(query, parsed)
+  if (parseCache.size > PARSE_CACHE_MAX_SIZE) {
+    const oldestKey = parseCache.keys().next().value
+    if (oldestKey !== undefined) parseCache.delete(oldestKey)
+  }
+
+  return parsed
+}
+
+// Recursively resolves the field names actually selected by a selection set, expanding fragment spreads and inline fragments.
+// A security check based only on direct field selections could be bypassed by wrapping a protected field call in a fragment.
+const collectFieldNames = (
+  fragmentsByName: ReadonlyMap<string, FragmentDefinitionNode>,
+  selectionSet: SelectionSetNode,
+  visitedFragmentNames = new Set<string>(),
+): Set<string> => {
+  const fieldNames = new Set<string>()
+
+  for (const selection of selectionSet.selections) {
+    switch (selection.kind) {
+      case Kind.FIELD:
+        fieldNames.add(selection.name.value)
+        break
+      case Kind.INLINE_FRAGMENT:
+        for (const fieldName of collectFieldNames(
+          fragmentsByName,
+          selection.selectionSet,
+          visitedFragmentNames,
+        )) {
+          fieldNames.add(fieldName)
+        }
+        break
+      case Kind.FRAGMENT_SPREAD: {
+        const fragmentName = selection.name.value
+        if (visitedFragmentNames.has(fragmentName)) break
+        visitedFragmentNames.add(fragmentName)
+
+        const fragment = fragmentsByName.get(fragmentName)
+        if (fragment) {
+          for (const fieldName of collectFieldNames(
+            fragmentsByName,
+            fragment.selectionSet,
+            visitedFragmentNames,
+          )) {
+            fieldNames.add(fieldName)
+          }
+        }
+        break
+      }
+    }
+  }
+
+  return fieldNames
+}
+
+// Determines whether the operation that will actually execute (resolved the same way the GraphQL executor resolves it: via operationName, or the sole operation if unambiguous) is a mutation or subscription that invokes at least one turnstile-protected field.
+// Anything ambiguous or unparseable is treated as requiring verification, so verification is still requested when unsure.
+const requiresTurnstileVerification = (
+  event: ProcessGraphQLRequestBodyEvent,
+) => {
+  const { operationName, query } = event.body
+
+  if (typeof query !== 'string') return true
+
+  const document = parseWithCache(query)
+  if (document === PARSE_ERROR) return true
+
+  const operation = getOperationAST(
+    document,
+    typeof operationName === 'string' ? operationName : undefined,
+  )
+
+  if (!operation) return true
+  // Only plain queries are exempt; both mutations and subscriptions can
+  // invoke protected fields and must be checked.
+  if (operation.operation === 'query') return false
+
+  const fragmentsByName = new Map(
+    document.definitions
+      .filter(
+        (definition): definition is FragmentDefinitionNode =>
+          definition.kind === Kind.FRAGMENT_DEFINITION,
+      )
+      .map((definition) => [definition.name.value, definition] as const),
+  )
+
+  const fieldNames = collectFieldNames(fragmentsByName, operation.selectionSet)
+  for (const fieldName of fieldNames) {
+    if (currentTurnstileProtectedFieldNames.has(fieldName)) return true
+  }
+
+  return false
+}
 
 const TurnstilePlugin: GraphileConfig.Plugin = {
   name: 'TurnstilePlugin',
   version: '0.0.0',
+  schema: {
+    hooks: {
+      // Root mutation fields backed by a custom function don't carry their pgResource in field scope (only computed columns and connection/list fields do), so instead of hooking each field, walk build.pgResources directly here: every resource tagged '@turnstileProtected' that's a mutation gets its final GraphQL field name computed via the same inflector graphile-build-pg itself uses to name that field, so this stays correct regardless of naming config.
+      build(build) {
+        const protectedFieldNames = new Set<string>()
+
+        type MutationResource = Parameters<
+          typeof build.inflection.customMutationField
+        >[0]['resource']
+
+        for (const resourceName in build.pgResources) {
+          const resource = build.pgResources[resourceName] as MutationResource
+
+          if (
+            resource.isMutation &&
+            resource.extensions?.tags?.['turnstileProtected']
+          ) {
+            protectedFieldNames.add(
+              build.inflection.customMutationField({ resource }),
+            )
+          }
+        }
+
+        build.turnstileProtectedFieldNames = protectedFieldNames
+
+        return build
+      },
+      // Table-backed CRUD mutations (createX/updateX/deleteX) always carry
+      // their originating `pgResource` in field scope, unlike the
+      // custom-function mutations handled above, so they're identified
+      // directly here instead of via inflector-based name guessing.
+      GraphQLObjectType_fields_field(field, build, context) {
+        const { scope } = context
+
+        if (
+          scope.isRootMutation &&
+          (scope.isPgCreateMutation ||
+            scope.isPgUpdateMutation ||
+            scope.isPgDeleteMutation) &&
+          scope.pgFieldResource?.extensions?.tags?.['turnstileProtected']
+        ) {
+          build.turnstileProtectedFieldNames.add(scope.fieldName)
+        }
+
+        return field
+      },
+      finalize(schema, build) {
+        // Publish the fully-populated Set in one atomic pointer swap; see
+        // the comment on `currentTurnstileProtectedFieldNames` above.
+        currentTurnstileProtectedFieldNames = build.turnstileProtectedFieldNames
+
+        return schema
+      },
+    },
+  },
   grafserv: {
     middleware: {
       async processGraphQLRequestBody(next, event) {
@@ -37,17 +270,27 @@ const TurnstilePlugin: GraphileConfig.Plugin = {
           return next()
         }
 
-        if (process.env['TURNSTILE_BYPASS']) {
+        if (TURNSTILE_BYPASS) {
           logger.debug('Turnstile bypass enabled, skipping verification.')
           return next()
         }
 
-        if (isQueryOnlyRequest(event)) {
-          logger.debug('Skipping verification for a query-only request.')
+        if (!requiresTurnstileVerification(event)) {
+          logger.debug(
+            'Skipping verification; no protected operation is invoked.',
+          )
           return next()
         }
 
-        const key = event.request.getHeader('x-turnstile-key')
+        const token = event.request.getHeader('x-turnstile-key')
+        logger.debug('Received Turnstile token', { present: Boolean(token) })
+
+        if (!token) {
+          logger.error('No Turnstile token provided.')
+          setStatusCode(event, 422)
+          throw new Error('Turnstile token not provided')
+        }
+
         const verificationTimeoutMs = 5000
         const controller = new AbortController()
         const timeout = setTimeout(
@@ -55,21 +298,16 @@ const TurnstilePlugin: GraphileConfig.Plugin = {
           verificationTimeoutMs,
         )
         let result: Response
-        logger.debug('Received token', key)
 
         try {
-          result = await fetch(
-            'http://vibetype:3000/api/internal/service/postgraphile/authentication',
-            {
-              body: JSON.stringify(event.body),
-              headers: {
-                ...(key ? { 'x-turnstile-key': key } : {}),
-                'content-type': 'application/json',
-              },
-              method: event.request.method,
-              signal: controller.signal,
-            },
-          )
+          result = await fetch(TURNSTILE_SITEVERIFY_URL, {
+            body: new URLSearchParams({
+              response: token,
+              secret: TURNSTILE_SECRET_KEY ?? '',
+            }),
+            method: 'POST',
+            signal: controller.signal,
+          })
         } catch (error) {
           logger.error('Verification request failed', error)
 
@@ -90,17 +328,35 @@ const TurnstilePlugin: GraphileConfig.Plugin = {
         } finally {
           clearTimeout(timeout)
         }
-        if (IS_DEV) {
-          logger.debug('Verification response', {
-            result,
-            body: await result.clone().text(),
+
+        if (!result.ok) {
+          logger.error('Verification service returned an error', {
+            status: result.status,
+            statusText: result.statusText,
+          })
+          setStatusCode(event, 503)
+          throw new Error('Turnstile verification service unavailable')
+        }
+
+        let verification: TurnstileSiteverifyResponse
+
+        try {
+          verification = (await result.json()) as TurnstileSiteverifyResponse
+        } catch (error) {
+          logger.error('Verification response could not be parsed', error)
+          setStatusCode(event, 503)
+          throw new Error('Turnstile verification service unavailable', {
+            cause: error,
           })
         }
 
-        if (!result.ok) {
+        if (IS_DEV) {
+          logger.debug('Verification response', verification)
+        }
+
+        if (!verification.success) {
           logger.error('Verification failed', {
-            status: result.status,
-            statusText: result.statusText,
+            errorCodes: verification['error-codes'],
           })
           setStatusCode(event, 401)
 


### PR DESCRIPTION
Turnstile verification is now driven by a `@turnstileProtected` smart comment tag on the Postgres resource instead of a hardcoded operation list, and tokens are checked against Cloudflare's siteverify endpoint directly rather than through the vibetype service.
The tag travels with the table or function, so renaming a mutation cannot silently drop its protection.

Mutations fail closed until the first schema build has published its set of protected field names, which matters because grafserv starts serving as soon as the preset resolves and `retryOnInitFail` can stretch that gap to minutes after a restart.
Rejections are thrown as `SafeError`s so their 401/422/503/504 status codes and messages actually reach the client; any other throw from this middleware is replaced by a generic `400 Parsing failed`, leaving the client unable to tell "re-run the challenge" from "my request was malformed".
The weak-password rejection had the same defect and now returns 422 as well.
Field selections are resolved through fragment spreads and inline fragments so a protected field cannot be hidden inside a fragment, and the siteverify timeout stays armed until the response body has been read rather than only until its headers arrive.
Whether a custom function is exposed under `Mutation` is decided by the same behavior check graphile-build-pg uses, so a `@behavior mutationField` function is covered too.

A tag that cannot take effect, because the resource exposes no root mutation field, is reported at schema build time instead of silently doing nothing.

`graphqlOperation.ts` resolves the operation with `getOperationAST`, the same function the executor uses to pick it, and memoizes parsed documents in a small LRU shared across requests rather than a per-request `WeakMap`.

The smoke test runs with a real `TURNSTILE_SECRET_KEY` instead of `TURNSTILE_BYPASS` and asserts that a protected mutation without a token is rejected with 422.

`TURNSTILE_SECRET_KEY` is required unless `TURNSTILE_BYPASS` is set to exactly `true`. Previously any non-empty value bypassed verification, so `TURNSTILE_BYPASS=false` silently disabled it.

Closes #41
